### PR TITLE
Suggestion: offer possibility to store typed values

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -10,8 +10,8 @@ import createKfs, { KeyFileStorage } from './src/key-file-storage';
  * * `false` to disable caching,
  * * `n: number` to cache the latest **n** accessed keys.
  */
-export default function keyFileStorage(path: string, caching?: number | boolean): KeyFileStorage {
+export default function keyFileStorage<P = any>(path: string, caching?: number | boolean): KeyFileStorage<P> {
   var cache = createCache(caching);
-  var kfs = createKfs(path, cache);
+  var kfs = createKfs<P>(path, cache);
   return kfs;
 }

--- a/src/key-file-storage.ts
+++ b/src/key-file-storage.ts
@@ -1,8 +1,8 @@
 import keyFileBasic from './key-file-basic';
 
-export interface KeyFileStorage {
-  [key: string]: any;
-  [index: number]: any;
+export interface KeyFileStorage<P> {
+  [key: string]: P;
+  [index: number]: P;
 
   <T, U = T>(key: string | number, value: T, callback?: (error: any) => U): Promise<U>;
   <T = any, U = T>(key: string | number, callback?: (error: any, value?: T) => U): Promise<U>;
@@ -11,7 +11,7 @@ export interface KeyFileStorage {
   <U = boolean>(callback?: (error: any) => U): Promise<U>;
 }
 
-export default function createKfs(kfsPath: string, cache: { [x: string]: any }): KeyFileStorage {
+export default function createKfs<P>(kfsPath: string, cache: { [x: string]: P }): KeyFileStorage<P> {
   var kfb = keyFileBasic(kfsPath, cache);
 
   // The produced promise and callback function related to the latest async 'in' operator


### PR DESCRIPTION
I am using key-file-storage to store and cache values and I find it error prone that values are typed as `any`. I propose to give the possibility to type the values (`any` by default).

Thus, a typical usage would be:
```
import kfs from 'key-file-storage';

type User = { 
    email: string, 
};

const store = kfs<User>('./data');

store['toto@gmail.com'] = { email: 'toto@gmail.com' }

```

It could probably even be extended to have typed keys.

What do you think?
